### PR TITLE
Problem when i try to serialize it

### DIFF
--- a/src/Aqua/Dynamic/DynamicObject.cs
+++ b/src/Aqua/Dynamic/DynamicObject.cs
@@ -13,6 +13,7 @@ namespace Aqua.Dynamic
     [Serializable]
     [DataContract(IsReference = true)]
     [DebuggerDisplay("Count = {PropertyCount}")]
+    [KnownType(typeof(DynamicObject))] // required hint for serializer
     public partial class DynamicObject : INotifyPropertyChanging, INotifyPropertyChanged
     {
         /// <summary>


### PR DESCRIPTION
When i use RemoteLinqEntityFramework conbining with ServiceModel.Grpc

System.Runtime.Serialization.SerializationException: Type 'Aqua.Dynamic.DynamicObject' with data contract name 'DynamicObject:http://schemas.datacontract.org/2004/07/Aqua.Dynamic' is not expected. Add any types not known statically to the list of known types - for example, by using the KnownTypeAttribute attribute or by adding them to the list of known types passed to DataContractSerializer.